### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,12 +18,18 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.4, 8.3]
-        laravel: [11.*]
+        laravel: [11.*, 12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
             carbon: ^2.63
+          - laravel: 12.*
+            testbench: 10.*
+            carbon: ^3.0
+          - laravel: 13.*
+            testbench: 11.*
+            carbon: ^3.8
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
   ],
   "require": {
     "php": "^8.3",
-    "illuminate/contracts": "^10.0|^11.0|^12.0"
+    "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0"
   },
   "require-dev": {
-    "orchestra/testbench": "^10.0",
+    "orchestra/testbench": "^10.0|^11.0",
     "nunomaduro/collision": "^8.6",
     "pestphp/pest": "^3.7",
     "pestphp/pest-plugin-arch": "^3.0",


### PR DESCRIPTION
## Summary
- Added `^13.0` to `illuminate/contracts` constraint in `composer.json`
- Added `^11.0` to `orchestra/testbench` dev dependency for Laravel 13 compatibility
- Expanded CI test matrix to cover Laravel 11, 12, and 13 with the correct testbench and carbon versions

## Test plan
- [ ] Verify CI passes for Laravel 11, 12, and 13 across PHP 8.3 and 8.4
- [ ] Confirm package installs correctly with `laravel/framework:^13.0`